### PR TITLE
Clean up most of the CLI project.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -348,3 +348,7 @@ MigrationBackup/
 
 # Ionide (cross platform F# VS Code tools) working folder
 .ionide/
+
+
+# JetBrains Rider cache/options directory
+.idea/

--- a/DogScepterCLI/Commands/ConfigsCommand.cs
+++ b/DogScepterCLI/Commands/ConfigsCommand.cs
@@ -7,7 +7,11 @@ using System.Threading.Tasks;
 
 namespace DogScepterCLI.Commands
 {
+    /// <summary>
+    /// The "configs" command, which lists available configuration files.
+    /// </summary>
     [Command("configs", Description = "Lists available configuration files.")]
+    // ReSharper disable once UnusedType.Global
     public class ConfigsCommand : ICommand
     {
         public ValueTask ExecuteAsync(IConsole console)

--- a/DogScepterCLI/Commands/CreateProjectCommand.cs
+++ b/DogScepterCLI/Commands/CreateProjectCommand.cs
@@ -54,22 +54,21 @@ namespace DogScepterCLI.Commands
         {
             console.Output.WriteLine();
 
-            string dir = ProjectDirectory ?? Environment.CurrentDirectory;
-            if (!Util.CheckExistingProject(console, dir))
-                return default;
+            // The project directory where we want to check for. Will get asked on / set depending on if we're in Interactive mode or not.
+            string dir;
 
             if (Interactive)
             {
                 // Perform basic prompts to initialize the project
                 DataFile ??= console.PromptFile("Enter location of data file");
+                dir = ProjectDirectory ?? console.PromptDirectory("Enter location of the project directory (\".\" for current directory)");
                 CompiledOutputDirectory ??= console.PromptDirectory("Enter directory to output compiled files to");
-                //TODO: ask for different project directory.
 
                 console.Output.WriteLine();
                 console.Output.WriteLine("Project details");
                 console.Output.WriteLine("===============");
-                console.Output.WriteLine($"Directory: {dir}");
                 console.Output.WriteLine($"Data file: {DataFile}");
+                console.Output.WriteLine($"Project directory: {dir}");
                 console.Output.WriteLine($"Output directory for compiled files: {CompiledOutputDirectory}");
                 console.Output.WriteLine();
                 if (!console.PromptYesNo("Are these details correct?"))
@@ -80,6 +79,8 @@ namespace DogScepterCLI.Commands
             }
             else
             {
+                dir = ProjectDirectory ?? Environment.CurrentDirectory;
+
                 if (DataFile == null || CompiledOutputDirectory == null)
                 {
                     console.Error.WriteLine("Missing arguments. Data file and output directory for compiled files must be set.");
@@ -90,6 +91,7 @@ namespace DogScepterCLI.Commands
                     console.Error.WriteLine("Data file does not exist.");
                     return default;
                 }
+                //TODO: maybe have feature to automatically create folders that don't exist?
                 if (!Directory.Exists(CompiledOutputDirectory))
                 {
                     console.Error.WriteLine("Output directory for compiled files does not exist.");
@@ -97,9 +99,10 @@ namespace DogScepterCLI.Commands
                 }
             }
 
-            if (!Util.CheckExistingProject(console, dir))
+            if (Util.CheckIfProjectExists(console, dir))
                 return default;
 
+            console.Output.WriteLine("Creating project...");
             // Initialize the project file
             GMData data = console.LoadDataFile(DataFile, Verbose);
             if (data == null)

--- a/DogScepterCLI/Commands/DumpCommand.cs
+++ b/DogScepterCLI/Commands/DumpCommand.cs
@@ -105,13 +105,16 @@ namespace DogScepterCLI.Commands
             if (data == null)
                 return default;
             ProjectFile pf = console.OpenProject(data, dir);
+            if (pf == null)
+                return default;
             pf.HackyComparisonMode = ComparisonMode;
 
-            // If any dump options were specified, set to true, otherwise false.
-            bool didAnything = (DumpTextures || DumpStrings || DumpCode || DumpRooms);
+            // If any dump options were specified, overwrite to true, otherwise false.
+            bool didAnything = false;
 
             if (DumpTextures)
             {
+                didAnything = true;
                 console.Output.WriteLine("Dumping textures...");
                 pf.Textures.ParseAllTextures();
                 for (int i = 0; i < pf.Textures.CachedTextures.Length; i++)
@@ -132,6 +135,7 @@ namespace DogScepterCLI.Commands
 
             if (DumpStrings)
             {
+                didAnything = true;
                 console.Output.WriteLine("Dumping strings...");
 
                 StringBuilder sb = new StringBuilder();
@@ -149,6 +153,7 @@ namespace DogScepterCLI.Commands
 
             if (DumpCode)
             {
+                didAnything = true;
                 console.Output.WriteLine("Dumping code...");
 
                 pf.DecompileCache = new DecompileCache(pf);
@@ -188,6 +193,7 @@ namespace DogScepterCLI.Commands
 
             if (DumpRooms)
             {
+                didAnything = true;
                 console.Output.WriteLine("Dumping rooms...");
 
                 string roomOutputDir = Path.Combine(dir, "rooms");

--- a/DogScepterCLI/Commands/DumpCommand.cs
+++ b/DogScepterCLI/Commands/DumpCommand.cs
@@ -16,36 +16,70 @@ using System.IO;
 using System.Linq;
 using System.Text;
 using System.Threading.Tasks;
+using DogScepterLib.Core.Models;
 
 namespace DogScepterCLI.Commands
 {
+    /// <summary>
+    /// The "dump" command, which dumps certain information from a GameMaker data file.
+    /// </summary>
     [Command("dump", Description = "Dumps certain information from an input data file path.")]
+    // ReSharper disable once UnusedType.Global
     public class DumpCommand : ICommand
     {
+        /// <summary>
+        /// File path to the GameMaker data file.
+        /// </summary>
         [CommandParameter(0, Description = "Input data file path.")]
         public string DataFile { get; private set; } = null;
 
+        /// <summary>
+        /// Directory path on where to output dumped files. If <see langword="null"/>, then the current working directory should be used.
+        /// </summary>
         [CommandOption("output", 'o', Description = "If not the working directory, specifies the output directory.")]
         public string OutputDirectory { get; private set; } = null;
 
+        /// <summary>
+        /// Whether to show verbose output from operations.
+        /// </summary>
         [CommandOption("verbose", 'v', Description = "Whether to show verbose output from operations.")]
         public bool Verbose { get; init; } = false;
 
+        /// <summary>
+        /// Whether to dump textures.
+        /// </summary>
         [CommandOption("textures", Description = "Dump textures.")]
         public bool DumpTextures { get; private set; }
 
+        /// <summary>
+        /// Whether to dump strings.
+        /// </summary>
         [CommandOption("strings", Description = "Dump strings.")]
         public bool DumpStrings { get; private set; }
 
+        /// <summary>
+        /// Whether to dump decompiled code.
+        /// </summary>
         [CommandOption("code", Description = "Dump decompiled code.")]
         public bool DumpCode { get; private set; }
 
+        /// <summary>
+        /// Whether to dump rooms as JSON.
+        /// </summary>
         [CommandOption("rooms", Description = "Dump room JSON.")]
         public bool DumpRooms { get; private set; }
 
+
+        /// <summary>
+        /// Whether to enable features more useful for comparing versions of a game
+        /// </summary>
         [CommandOption("hackycompare", Description = "Enables hacky comparison mode.")]
         public bool ComparisonMode { get; private set; }
 
+
+        /// <summary>
+        /// The name of the macro config that should be used.
+        /// </summary>
         [CommandOption("config", Description = "Set the configuration to use.")]
         public string Config { get; private set; } = null;
 
@@ -71,15 +105,13 @@ namespace DogScepterCLI.Commands
             if (data == null)
                 return default;
             ProjectFile pf = console.OpenProject(data, dir);
-            if (data == null)
-                return default;
             pf.HackyComparisonMode = ComparisonMode;
 
-            bool didAnything = false;
+            // If any dump options were specified, set to true, otherwise false.
+            bool didAnything = (DumpTextures || DumpStrings || DumpCode || DumpRooms);
 
             if (DumpTextures)
             {
-                didAnything = true;
                 console.Output.WriteLine("Dumping textures...");
                 pf.Textures.ParseAllTextures();
                 for (int i = 0; i < pf.Textures.CachedTextures.Length; i++)
@@ -93,18 +125,17 @@ namespace DogScepterCLI.Commands
                     }
                     catch (Exception e)
                     {
-                        console.Output.WriteLine($"Failed to save texture {i}: {e.Message}");
+                        console.Error.WriteLine($"Failed to save texture {i}: {e.Message}");
                     }
                 }
             }
 
             if (DumpStrings)
             {
-                didAnything = true;
                 console.Output.WriteLine("Dumping strings...");
 
                 StringBuilder sb = new StringBuilder();
-                foreach (var str in pf.DataHandle.GetChunk<GMChunkSTRG>().List)
+                foreach (GMString str in pf.DataHandle.GetChunk<GMChunkSTRG>().List)
                     sb.AppendLine(str.ToString());
                 try
                 {
@@ -112,13 +143,12 @@ namespace DogScepterCLI.Commands
                 }
                 catch (Exception e)
                 {
-                    console.Output.WriteLine($"Failed to save strings: {e.Message}");
+                    console.Error.WriteLine($"Failed to save strings: {e.Message}");
                 }
             }
 
             if (DumpCode)
             {
-                didAnything = true;
                 console.Output.WriteLine("Dumping code...");
 
                 pf.DecompileCache = new DecompileCache(pf);
@@ -128,11 +158,11 @@ namespace DogScepterCLI.Commands
                     try
                     {
                         if (!pf.DecompileCache.Types.AddFromConfigFile(Config))
-                            console.Output.WriteLine($"Didn't find a macro type config named \"{Config}\".");
+                            console.Error.WriteLine($"Didn't find a macro type config named \"{Config}\".");
                     }
                     catch (Exception ex)
                     {
-                        console.Output.WriteLine($"Failed to load macro type config: {ex}");
+                        console.Error.WriteLine($"Failed to load macro type config: {ex}");
                     }
                 }
 
@@ -151,14 +181,13 @@ namespace DogScepterCLI.Commands
                     }
                     catch (Exception e)
                     {
-                        console.Output.WriteLine($"Failed to decompile code for \"{elem.Name.Content}\": {e}");
+                        console.Error.WriteLine($"Failed to decompile code for \"{elem.Name.Content}\": {e}");
                     }
                 });
             }
 
             if (DumpRooms)
             {
-                didAnything = true;
                 console.Output.WriteLine("Dumping rooms...");
 
                 string roomOutputDir = Path.Combine(dir, "rooms");
@@ -173,19 +202,15 @@ namespace DogScepterCLI.Commands
                     }
                     catch (Exception e)
                     {
-                        console.Output.WriteLine($"Failed to export room data for \"{pf.Rooms[i].Name}\": {e}");
+                        console.Error.WriteLine($"Failed to export room data for \"{pf.Rooms[i].Name}\": {e}");
                     }
                 }
             }
 
             if (didAnything)
-            {
                 console.Output.WriteLine("Complete.");
-            }
             else
-            {
                 console.Output.WriteLine("Did nothing. Need to specify using parameters what to dump.");
-            }
 
             return default;
         }

--- a/DogScepterCLI/Commands/OpenProjectCommand.cs
+++ b/DogScepterCLI/Commands/OpenProjectCommand.cs
@@ -13,21 +13,40 @@ using System.Threading.Tasks;
 
 namespace DogScepterCLI.Commands
 {
+    /// <summary>
+    /// The "open" command, which opens an existing DogScepter project.
+    /// </summary>
     [Command("open", Description = "Opens an existing DogScepter project.")]
+    // ReSharper disable once UnusedType.Global
     public class OpenProjectCommand : ICommand
     {
+        /// <summary>
+        /// File path that should be associated with the DogScepter project, if there wasn't one associated already.
+        /// </summary>
         [CommandOption("input", 'i', Description = "Input data file path, if necessary.")]
         public string DataFile { get; private set; } = null;
 
+        /// <summary>
+        /// Directory path on where to output compiled files. If <see langword="null"/>, then the current working directory should be used.
+        /// </summary>
         [CommandOption("output", 'o', Description = "Output directory, if necessary.")]
-        public string OutputDirectory { get; private set; } = null;
+        public string CompiledOutputDirectory { get; private set; } = null;
 
+        /// <summary>
+        /// Whether to show verbose output from operations.
+        /// </summary>
         [CommandOption("verbose", 'v', Description = "Whether to show verbose output from operations.")]
         public bool Verbose { get; init; } = false;
 
+        /// <summary>
+        /// The path where the DogScepter project gets created. If <see langword="null"/>, then the current working directory should be used.
+        /// </summary>
         [CommandOption("dir", 'd', Description = "If not the working directory, specifies the project location.")]
         public string ProjectDirectory { get; init; } = null;
 
+        /// <summary>
+        /// Whether to use an interactive shell.
+        /// </summary>
         [CommandOption("int", Description = "Whether to use interactive shell.")]
         public bool Interactive { get; init; } = true;
 
@@ -36,7 +55,7 @@ namespace DogScepterCLI.Commands
             console.Output.WriteLine();
 
             string dir = ProjectDirectory ?? Environment.CurrentDirectory;
-            if (!CheckExisting(console, dir))
+            if (!Util.CheckExistingProject(console, dir))
                 return default;
 
             MachineConfig cfg = MachineConfig.Load();
@@ -45,6 +64,7 @@ namespace DogScepterCLI.Commands
                 // We have a config for this project, but we need to verify it
                 if (!File.Exists(pcfg.InputFile))
                 {
+                    //TODO: this is slightly confusing. Read this later and comment on what this actually is supposed to do.
                     console.Error.WriteLine("Data file no longer exists!");
                     if (Interactive)
                         DataFile ??= console.PromptFile("Enter new location of data file");
@@ -64,22 +84,23 @@ namespace DogScepterCLI.Commands
 
                 if (!Directory.Exists(pcfg.OutputDirectory))
                 {
+                    //TODO: see above todo
                     console.Error.WriteLine("Output directory no longer exists!");
                     if (Interactive)
-                        OutputDirectory ??= console.PromptDirectory("Enter new directory to output files to");
-                    else if (OutputDirectory == null)
+                        CompiledOutputDirectory ??= console.PromptDirectory("Enter new directory to output files to");
+                    else if (CompiledOutputDirectory == null)
                     {
                         console.Error.WriteLine("Missing arguments. Output directory must be set.");
                         return default;
                     }
-                    else if (!Directory.Exists(OutputDirectory))
+                    else if (!Directory.Exists(CompiledOutputDirectory))
                     {
                         console.Error.WriteLine("Provided output directory also does not exist.");
                         return default;
                     }
                 }
                 else
-                    OutputDirectory = pcfg.OutputDirectory;
+                    CompiledOutputDirectory = pcfg.OutputDirectory;
             }
             else
             {
@@ -87,11 +108,11 @@ namespace DogScepterCLI.Commands
                 if (Interactive)
                 {
                     DataFile ??= console.PromptFile("Enter location of data file");
-                    OutputDirectory ??= console.PromptDirectory("Enter directory to output files to");
+                    CompiledOutputDirectory ??= console.PromptDirectory("Enter directory to output files to");
                 }
                 else
                 {
-                    if (DataFile == null || OutputDirectory == null)
+                    if (DataFile == null || CompiledOutputDirectory == null)
                     {
                         console.Error.WriteLine("Missing arguments. Data file and output directory must be set, as this project is not yet registered.");
                         return default;
@@ -101,7 +122,7 @@ namespace DogScepterCLI.Commands
                         console.Error.WriteLine("Data file does not exist.");
                         return default;
                     }
-                    if (!Directory.Exists(OutputDirectory))
+                    if (!Directory.Exists(CompiledOutputDirectory))
                     {
                         console.Error.WriteLine("Output directory does not exist.");
                         return default;
@@ -109,11 +130,11 @@ namespace DogScepterCLI.Commands
                 }
             }
 
-            if (!CheckExisting(console, dir))
+            if (!Util.CheckExistingProject(console, dir))
                 return default;
 
             // Save potential changes to config
-            var newPcfg = new ProjectConfig(DataFile, OutputDirectory);
+            var newPcfg = new ProjectConfig(DataFile, CompiledOutputDirectory);
             cfg.EditProject(dir, newPcfg);
             MachineConfig.Save(cfg);
 
@@ -122,8 +143,6 @@ namespace DogScepterCLI.Commands
             if (data == null)
                 return default;
             ProjectFile pf = console.OpenProject(data, dir);
-            if (data == null)
-                return default;
 
             if (Interactive)
                 ProjectShell.Run(console, pf, newPcfg, Verbose);
@@ -131,21 +150,6 @@ namespace DogScepterCLI.Commands
             return default;
         }
 
-        private bool CheckExisting(IConsole console, string dir)
-        {
-            if (!Directory.Exists(dir))
-            {
-                console.Error.WriteLine("Project directory does not exist.");
-                return false;
-            }
 
-            if (!File.Exists(Path.Combine(dir, "project.json")))
-            {
-                console.Error.WriteLine("No project exists in this location.");
-                return false;
-            }
-
-            return true;
-        }
     }
 }

--- a/DogScepterCLI/Commands/OpenProjectCommand.cs
+++ b/DogScepterCLI/Commands/OpenProjectCommand.cs
@@ -55,17 +55,19 @@ namespace DogScepterCLI.Commands
             console.Output.WriteLine();
 
             string dir = ProjectDirectory ?? Environment.CurrentDirectory;
-            if (!Util.CheckExistingProject(console, dir))
+            if (!Util.CheckIfProjectExists(console, dir))
                 return default;
 
             MachineConfig cfg = MachineConfig.Load();
             if (cfg.Projects.TryGetValue(dir, out ProjectConfig pcfg))
             {
                 // We have a config for this project, but we need to verify it
+
+                // Verify that the data file associated with the project still exists,
+                // if not prompt for new data file / read it from arguments
                 if (!File.Exists(pcfg.InputFile))
                 {
-                    //TODO: this is slightly confusing. Read this later and comment on what this actually is supposed to do.
-                    console.Error.WriteLine("Data file no longer exists!");
+                    console.Error.WriteLine("Data file linked to the project no longer exists!");
                     if (Interactive)
                         DataFile ??= console.PromptFile("Enter new location of data file");
                     else if (DataFile == null)
@@ -82,9 +84,10 @@ namespace DogScepterCLI.Commands
                 else
                     DataFile = pcfg.InputFile;
 
+                // Verify that the compiled output directory associated with the project still exists,
+                // if not prompt for new directory / read from arguments
                 if (!Directory.Exists(pcfg.OutputDirectory))
                 {
-                    //TODO: see above todo
                     console.Error.WriteLine("Output directory no longer exists!");
                     if (Interactive)
                         CompiledOutputDirectory ??= console.PromptDirectory("Enter new directory to output files to");
@@ -130,7 +133,7 @@ namespace DogScepterCLI.Commands
                 }
             }
 
-            if (!Util.CheckExistingProject(console, dir))
+            if (!Util.CheckIfProjectExists(console, dir))
                 return default;
 
             // Save potential changes to config
@@ -143,6 +146,8 @@ namespace DogScepterCLI.Commands
             if (data == null)
                 return default;
             ProjectFile pf = console.OpenProject(data, dir);
+            if (pf == null)
+                return default;
 
             if (Interactive)
                 ProjectShell.Run(console, pf, newPcfg, Verbose);

--- a/DogScepterCLI/ConsoleExtensions.cs
+++ b/DogScepterCLI/ConsoleExtensions.cs
@@ -2,31 +2,51 @@
 using DogScepterLib.Core;
 using DogScepterLib.Project;
 using System;
-using System.Collections.Generic;
 using System.IO;
 using System.Linq;
-using System.Text;
-using System.Threading.Tasks;
 
 namespace DogScepterCLI
 {
     public static class ConsoleExtensions
     {
-        public static string ReadString(this IConsole console, string msg)
+        /// <summary>
+        /// Reads a string a line from the console, while displaying a message.
+        /// </summary>
+        /// <param name="console">The console from where the string will be read from.</param>
+        /// <param name="message">The message to display.</param>
+        /// <returns></returns>
+        public static string ReadString(this IConsole console, string message)
         {
-            console.Output.Write($"> {msg}: ");
-            return console.Input.ReadLine();
+            console.Output.Write($"> {message}: ");
+            return console.Input.ReadLine()?.Trim();
         }
 
-        public static bool PromptYesNo(this IConsole console, string msg)
+        /// <summary>
+        /// Does a Yes/No prompt from the console, while displaying a message.
+        /// </summary>
+        /// <param name="console">The console from where the Yes/No prompt will be done from.</param>
+        /// <param name="message">The message to display.</param>
+        /// <returns><see langword="true"/> if <c>Y</c> or <c>y</c> was inputted, otherwise <see langword="false"/>.</returns>
+        public static bool PromptYesNo(this IConsole console, string message)
         {
-            console.Output.Write($"> {msg} (Y/n): ");
-            return char.ToLowerInvariant(console.Input.ReadLine().FirstOrDefault()) == 'y';
+            console.Output.Write($"> {message} (y/N): ");
+            // ReadLine can return null, so if it does, we'll use ' ' instead.
+            char firstCharOfInput = console.Input.ReadLine()?.FirstOrDefault() ?? ' ';
+            return Char.ToLowerInvariant(firstCharOfInput) == 'y';
         }
 
-        public static string PromptDirectory(this IConsole console, string msg)
+        /// <summary>
+        /// Prompts for a directory path, while displaying a custom message.
+        /// </summary>
+        /// <param name="console">The console from where the directory prompt will be done from.</param>
+        /// <param name="message">The message to display.</param>
+        /// <returns>The directory path that was inputted.</returns>
+        /// <remarks>This method will be in a <c>do...while</c> loop until a directory path that exists was inputted. <br/>
+        /// Should the directory path not exist, another prompt will appear to create the directory. An affirmative input will create that directory,
+        /// while ignoring all exceptions that could occur. A negative input will continue to prompt for another directory.</remarks>
+        public static string PromptDirectory(this IConsole console, string message)
         {
-            string dir = Util.RemoveQuotes(console.ReadString(msg));
+            string dir = Util.RemoveQuotes(console.ReadString(message));
 
             while (!Directory.Exists(dir))
             {
@@ -39,7 +59,7 @@ namespace DogScepterCLI
                     }
                     catch (Exception e)
                     {
-                        console.Output.Write($"Failed to create directory: {e.Message}");
+                        console.Error.Write($"Failed to create directory: {e.Message}");
                     }
                 }
                 else
@@ -51,9 +71,17 @@ namespace DogScepterCLI
             return dir;
         }
 
-        public static string PromptFile(this IConsole console, string msg)
+        /// <summary>
+        /// Prompts for a file path, while displaying a custom method.
+        /// </summary>
+        /// <param name="console">The console from where the file prompt will be done from.</param>
+        /// <param name="message">The message to display</param>
+        /// <returns>The file path that was inputted.</returns>
+        /// <remarks>This method will do a <c>do..while</c> loop until a file path that exists will was inputted,
+        /// continuing to prompt for another file path if it doesn't.</remarks>
+        public static string PromptFile(this IConsole console, string message)
         {
-            string file = Util.RemoveQuotes(console.ReadString(msg));
+            string file = Util.RemoveQuotes(console.ReadString(message));
 
             while (!File.Exists(file))
             {
@@ -87,17 +115,25 @@ namespace DogScepterCLI
             }
         }
 
+        /// <summary>
+        /// Opens a new DogScepter project and returns it as a <see cref="ProjectFile"/>.
+        /// </summary>
+        /// <param name="console">The console from where the DogScepter project should be opened..</param>
+        /// <param name="data">The GameMaker data file that should be associated for the project.</param>
+        /// <param name="directory">The directory path to where the DogScepter project is located.</param>
+        /// <returns>The opened DogScepter project as a <see cref="ProjectFile"/>.</returns>
         public static ProjectFile OpenProject(this IConsole console, GMData data, string directory)
         {
             console.Output.WriteLine("Opening project...");
             try
             {
-                ProjectFile pf = new ProjectFile(data, directory,
+                ProjectFile projectFile = new ProjectFile(data, directory,
                 (ProjectFile.WarningType type, string info) =>
                 {
                     console.Output.WriteLine($"[WARN: {type}] {info ?? ""}");
                 });
-                return pf;
+                console.Output.WriteLine("Project opened.");
+                return projectFile;
             }
             catch (Exception e)
             {
@@ -106,12 +142,18 @@ namespace DogScepterCLI
             }
         }
 
-        public static bool SaveProject(this IConsole console, ProjectFile pf)
+        /// <summary>
+        /// Saves a DogScepter project file.
+        /// </summary>
+        /// <param name="console">The console from where the DogScepter project file should be saved..</param>
+        /// <param name="projectFile">The DogScepter project file that should get saved.</param>
+        /// <returns><see langword="true"/> if saving was successful, otherwise <see langword="false"/>.</returns>
+        public static bool SaveProject(this IConsole console, ProjectFile projectFile)
         {
             console.Output.WriteLine("Saving project...");
             try
             {
-                pf.SaveAll();
+                projectFile.SaveAll();
             }
             catch (Exception e)
             {

--- a/DogScepterCLI/ConsoleExtensions.cs
+++ b/DogScepterCLI/ConsoleExtensions.cs
@@ -92,6 +92,13 @@ namespace DogScepterCLI
             return file;
         }
 
+        /// <summary>
+        /// Loads a GameMaker data file, parses it and returns it as a <see cref="GMData"/> representation.
+        /// </summary>
+        /// <param name="console">The console on where to output messages to.</param>
+        /// <param name="file">The path to the GameMaker data file.</param>
+        /// <param name="verbose">Whether to show verbose output.</param>
+        /// <returns>A GameMaker data file as <see cref="GMData"/>.</returns>
         public static GMData LoadDataFile(this IConsole console, string file, bool verbose = false)
         {
             console.Output.WriteLine("Loading data file...");
@@ -118,7 +125,7 @@ namespace DogScepterCLI
         /// <summary>
         /// Opens a new DogScepter project and returns it as a <see cref="ProjectFile"/>.
         /// </summary>
-        /// <param name="console">The console from where the DogScepter project should be opened..</param>
+        /// <param name="console">The console on where to output messages to.</param>
         /// <param name="data">The GameMaker data file that should be associated for the project.</param>
         /// <param name="directory">The directory path to where the DogScepter project is located.</param>
         /// <returns>The opened DogScepter project as a <see cref="ProjectFile"/>.</returns>
@@ -145,7 +152,7 @@ namespace DogScepterCLI
         /// <summary>
         /// Saves a DogScepter project file.
         /// </summary>
-        /// <param name="console">The console from where the DogScepter project file should be saved..</param>
+        /// <param name="console">The console on where output messages to.</param>
         /// <param name="projectFile">The DogScepter project file that should get saved.</param>
         /// <returns><see langword="true"/> if saving was successful, otherwise <see langword="false"/>.</returns>
         public static bool SaveProject(this IConsole console, ProjectFile projectFile)

--- a/DogScepterCLI/ProjectShell.cs
+++ b/DogScepterCLI/ProjectShell.cs
@@ -58,7 +58,7 @@ namespace DogScepterCLI
                             continue;
                     }
                     indices.Add(ind);
-                }   
+                }
             }
 
             pf.AddAssetsToJSON(list, indices, true);
@@ -119,9 +119,10 @@ namespace DogScepterCLI
                 args =>
                 {
                     // TODO prompt to save anything? maybe not?
-                    return Command.CommandResult.Quit; 
+                    return Command.CommandResult.Quit;
                 }),
 
+                //TODO: don't just straight up crash, if project file doesn't exist anymore, needs to be fixed in OpenProject
                 new Command(new[] { "reload" },
                 "Reloads the project as it currently is on disk.",
                 "reload <optional:data>",
@@ -244,7 +245,7 @@ namespace DogScepterCLI
 
                         foreach (var cmd in commands)
                         {
-                            console.Output.WriteLine(cmd.Usage + new string(' ', helpLength - cmd.Usage.Length) + 
+                            console.Output.WriteLine(cmd.Usage + new string(' ', helpLength - cmd.Usage.Length) +
                                                         " |  " + cmd.Description);
                         }
                     }

--- a/DogScepterCLI/Util.cs
+++ b/DogScepterCLI/Util.cs
@@ -28,24 +28,24 @@ namespace DogScepterCLI
         /// <summary>
         /// Check whether a DogScepter project already exists in a certain location.
         /// </summary>
-        /// <param name="console">The console to use for </param>
-        /// <param name="dir"></param>
-        /// <returns><see langword="false"/> if the project exists at that location or the project directory does not exist, otherwise <see langword="true"/>.</returns>
-        //TODO: rename function to be more clear
-        public static bool CheckExistingProject(IConsole console, string dir)
+        /// <param name="console">The console to use for outputting Errors to.</param>
+        /// <param name="dir">The directory to check if it contains a DogScepter project.</param>
+        /// <returns><see langword="false"/> if the project does not exist at that location or the project directory does not exist, otherwise <see langword="true"/>.</returns>
+        public static bool CheckIfProjectExists(IConsole console, string dir)
         {
             if (!Directory.Exists(dir))
             {
-                console.Error.WriteLine("Project directory does not exist.");
+                console.Error.WriteLine($"{dir} does not exist.");
                 return false;
             }
 
             if (!File.Exists(Path.Combine(dir, "project.json")))
             {
-                console.Error.WriteLine("No project exists in this location.");
+                console.Error.WriteLine($"No project exists in {dir}.");
                 return false;
             }
 
+            console.Output.WriteLine($"Project exists at {dir}");
             return true;
         }
     }

--- a/DogScepterCLI/Util.cs
+++ b/DogScepterCLI/Util.cs
@@ -1,20 +1,52 @@
-﻿using DogScepterLib.Core;
-using System;
-using System.Collections.Generic;
-using System.IO;
-using System.Linq;
-using System.Text;
-using System.Threading.Tasks;
+﻿using System.IO;
+using CliFx.Infrastructure;
 
 namespace DogScepterCLI
 {
+    /// <summary>
+    /// Class that contains several utility methods.
+    /// </summary>
     public static class Util
     {
+        /// <summary>
+        /// Removes double quotes or single quotes from a path, should it be surrounded by them.
+        /// </summary>
+        /// <param name="path">The path to remove quotes from.</param>
+        /// <returns><paramref name="path"/> without quotes at the beginning and end of it.</returns>
         public static string RemoveQuotes(string path)
         {
-            if (path.Length >= 2 && path.StartsWith('"') && path.EndsWith('"'))
-                return path[1..^1];
+            if (path.Length >= 2)
+            {
+                // Some file explorers (primarily on Linux) surround file paths with ' instead of "
+                if ((path.StartsWith('"') && path.EndsWith('"')) ||
+                    (path.StartsWith('\'') && path.EndsWith('\'')))
+                    return path[1..^1];
+            }
             return path;
+        }
+
+        /// <summary>
+        /// Check whether a DogScepter project already exists in a certain location.
+        /// </summary>
+        /// <param name="console">The console to use for </param>
+        /// <param name="dir"></param>
+        /// <returns><see langword="false"/> if the project exists at that location or the project directory does not exist, otherwise <see langword="true"/>.</returns>
+        //TODO: rename function to be more clear
+        public static bool CheckExistingProject(IConsole console, string dir)
+        {
+            if (!Directory.Exists(dir))
+            {
+                console.Error.WriteLine("Project directory does not exist.");
+                return false;
+            }
+
+            if (!File.Exists(Path.Combine(dir, "project.json")))
+            {
+                console.Error.WriteLine("No project exists in this location.");
+                return false;
+            }
+
+            return true;
         }
     }
 }


### PR DESCRIPTION
This cleans up most of the CLI project except for ProjectShell.cs as I wanna tackle it another time and to not make the PR to big.

- Adds documentation for classes/attributes/methods
- Clean some methods up slightly (RemoveQuotes to compensate for linux quotes, PromptYesNo to prevent a crash)
- Write error messages to STDERR instead of STDOUT
- adds Rider files to the gitignore
- Puts CheckExistingProject into Utils since its accessed by multiple methods
- Renames some variables slightly to be more clear
- Adds a few todos on things that should be still done.

Also fixes #29 