### PR TITLE
Fixes compiler emitting malformed chain calls

### DIFF
--- a/DogScepterLib/Project/GML/Compiler/Bytecode.cs
+++ b/DogScepterLib/Project/GML/Compiler/Bytecode.cs
@@ -591,6 +591,13 @@ public static partial class Bytecode
 
         if (ctx.BaseContext.IsGMS23)
         {
+            // Arguments get pushed in reverse order
+            for (int i = func.Children.Count - 1; i >= 0; i--)
+            {
+                CompileExpression(ctx, func.Children[i]);
+                ConvertTo(ctx, DataType.Variable);
+            }
+            
             if (inChain)
             {
                 // Handle calling at the end of a chain
@@ -610,13 +617,6 @@ public static partial class Bytecode
             }
             else
             {
-                // Arguments get pushed in reverse order
-                for (int i = func.Children.Count - 1; i >= 0; i--)
-                {
-                    CompileExpression(ctx, func.Children[i]);
-                    ConvertTo(ctx, DataType.Variable);
-                }
-
                 EmitCall(ctx, Opcode.Call, DataType.Int32, tokenFunc, func.Children.Count, token, funcRef);
                 ctx.TypeStack.Push(DataType.Variable);
             }


### PR DESCRIPTION
In `CompileFunctionCall`, the `IsGMS23` -> `inChain` branch wouldn't compile call children. This resulted in an interpreter stack underrun, followed by a hard interpreter crash (no error log), if the call in question had any arguments.