### PR TITLE
Fixes multiple texture generation bugs

### DIFF
--- a/DogScepterLib/Core/Models/GMTextureItem.cs
+++ b/DogScepterLib/Core/Models/GMTextureItem.cs
@@ -112,7 +112,7 @@ namespace DogScepterLib.Core.Models
                 // This is fully transparent, just grab one pixel
                 SourceWidth = 1;
                 SourceHeight = 1;
-                _Image = new DSImage(_Image, 0, 0, 1, 1);
+                _Image = new DSImage(_Image, SourceX, SourceY, SourceWidth, SourceHeight);
             }
             else if (left != 0 || top != 0 || right != BoundWidth - 1 || bottom != BoundHeight - 1)
             {
@@ -123,9 +123,11 @@ namespace DogScepterLib.Core.Models
                 SourceHeight = (ushort)(bottom - top);
                 TargetWidth = SourceWidth;
                 TargetHeight = SourceHeight;
-                TargetX = (ushort)left;
-                TargetY = (ushort)top;
-                _Image = new DSImage(_Image, left, top, right - left, bottom - top);
+                SourceX = (ushort)left;
+                SourceY = (ushort)top;
+                TargetX = SourceX;
+                TargetY = SourceY;
+                _Image = new DSImage(_Image, SourceX, SourceY, SourceWidth, SourceHeight);
             }
         }
 

--- a/DogScepterLib/Core/Models/GMTextureItem.cs
+++ b/DogScepterLib/Core/Models/GMTextureItem.cs
@@ -112,6 +112,7 @@ namespace DogScepterLib.Core.Models
                 // This is fully transparent, just grab one pixel
                 SourceWidth = 1;
                 SourceHeight = 1;
+                _Image = new DSImage(_Image, 0, 0, 1, 1);
             }
             else if (left != 0 || top != 0 || right != BoundWidth - 1 || bottom != BoundHeight - 1)
             {

--- a/DogScepterLib/Project/Textures.cs
+++ b/DogScepterLib/Project/Textures.cs
@@ -817,8 +817,8 @@ namespace DogScepterLib.Project
                 fixed (byte* bytePtr = &texture.Data[0],
                              entryBytePtr = &entryTexture.Data[0])
                 {
-                    int* ptr = (int*)bytePtr + (self.SourceX + (self.SourceY * texture.Width));
-                    int* entryPtr = (int*)entryBytePtr + (entry.SourceX + (entry.SourceY * entryTexture.Width));
+                    int* ptr = (int*)bytePtr + (self.TargetX + (self.TargetY * texture.Width));
+                    int* entryPtr = (int*)entryBytePtr + (entry.TargetX + (entry.TargetY * entryTexture.Width));
 
                     bool checking = true;
                     for (int y = 0; y < self.SourceHeight && checking; y++)
@@ -833,8 +833,8 @@ namespace DogScepterLib.Project
                             ptr++;
                             entryPtr++;
                         }
-                        ptr += texture.Width - self.SourceWidth;
-                        entryPtr += entryTexture.Width - self.SourceWidth;
+                        ptr += texture.RealWidth - self.SourceWidth;
+                        entryPtr += entryTexture.RealWidth - self.SourceWidth;
                     }
 
                     if (checking)

--- a/DogScepterLib/Project/Textures.cs
+++ b/DogScepterLib/Project/Textures.cs
@@ -817,8 +817,8 @@ namespace DogScepterLib.Project
                 fixed (byte* bytePtr = &texture.Data[0],
                              entryBytePtr = &entryTexture.Data[0])
                 {
-                    int* ptr = (int*)bytePtr + (self.TargetX + (self.TargetY * texture.Width));
-                    int* entryPtr = (int*)entryBytePtr + (entry.TargetX + (entry.TargetY * entryTexture.Width));
+                    int* ptr = (int*)bytePtr + (self.SourceX + (self.SourceY * texture.RealWidth));
+                    int* entryPtr = (int*)entryBytePtr + (entry.SourceX + (entry.SourceY * entryTexture.RealWidth));
 
                     bool checking = true;
                     for (int y = 0; y < self.SourceHeight && checking; y++)


### PR DESCRIPTION
Fixes `CompareHashedTextures` emitting false positives and false negatives, resulting in missing sprites or sprites not being deduplicated.

Fixes texture cropping failing to reduce fully transparent texture images to 1x1, resulting in sprites being overwritten with empty pixels, or in texture generation crashing due to unexpected image size.